### PR TITLE
Fixed bug with error.data. It can be an object after decoding too.

### DIFF
--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -415,7 +415,11 @@ class Client
     {
       $code = $error->code;
       $message = $error->message;
-      $data = isset($error->data) ? $error->data : null;
+      $data = null;
+      if (isset($error->data))
+      {
+          $data = is_object($error->data) ? json_encode($error->data) : $error->data;
+      }
     }
 
     $data = $data ? ': ' . $data : '';


### PR DESCRIPTION
See http://www.jsonrpc.org/specification#error_object
